### PR TITLE
Make inventory letters start at lower case

### DIFF
--- a/src/components/Screens/InventoryScreen.ts
+++ b/src/components/Screens/InventoryScreen.ts
@@ -29,7 +29,7 @@ export class InventoryScreen extends BaseScreen {
    * @returns {string} The corresponding character.
    */
   positionToCharacter(pos: number): string {
-    return String.fromCharCode(65 + pos);
+    return String.fromCharCode(97 + pos);
   }
 
   /**


### PR DESCRIPTION
As the input is (or should be) case sensitive and entering a lower case 'a' selects the first inventory item, the letter displayed should also be lower case to avoid confusion.